### PR TITLE
[FEAT] 일반 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
+	id 'org.springframework.boot' version '3.3.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -28,12 +28,20 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// spring mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/project/ping/PingApplication.java
+++ b/src/main/java/project/ping/PingApplication.java
@@ -1,12 +1,12 @@
 package project.ping;
 
-import jakarta.persistence.EntityListeners;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EntityListeners(AuditingEntityListener.class)
+@EnableJpaAuditing
 public class PingApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/project/ping/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/project/ping/apiPayload/status/ErrorStatus.java
@@ -17,6 +17,11 @@ public enum ErrorStatus {
     // 가게 관련 응답
     NOT_EXIST_STORE(HttpStatus.BAD_REQUEST, "STORE4001", "존재하지 않는 가게입니다"),
     NOT_EXIST_MENU(HttpStatus.BAD_REQUEST, "STORE4002", "해당 가게에 메뉴가 존재하지 않습니다"),
+
+    // 회원 관련 응답
+    EXIST_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4001", "이미 회원가입한 이메일입니다. 다른 이메일로 가입하세요"),
+    WRONG_EMAIL_VERIFICATOIN(HttpStatus.BAD_REQUEST, "MEMBER4002", "이메일 인증번호가 틀렸습니다. 다시 입력해주세요"),
+    EXPIRE_EMAIL_CODE(HttpStatus.BAD_REQUEST, "MEMBER4003", "이메일 인증번호가 만료되었습니다. 다시 인증번호를 받으세요"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/project/ping/config/EmailConfig.java
+++ b/src/main/java/project/ping/config/EmailConfig.java
@@ -1,0 +1,60 @@
+package project.ping.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Bean
+    public JavaMailSender javaMailsender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        // 추가 설정(인증, 암호화, 타임아웃 등)
+        mailSender.setJavaMailProperties(getMailProperties());
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.starttls.enable", starttlsEnable);
+        props.put("mail.smtp.starttls.required", starttlsRequired);
+        props.put("mail.smtp.timeout", timeout);
+        return props;
+    }
+
+}

--- a/src/main/java/project/ping/config/RedisConfig.java
+++ b/src/main/java/project/ping/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package project.ping.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    // LettuceConnectionFactory 객체를 생성하여 반환하는 메서드
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    // Redis 작업을 수행하기 위해 RedisTemplate 객체를 생성하여 반환하는 메서드
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // 일반적인 key-value의 경우 Serializer
+        // StringSerializer : 문자열 그대로 저장함
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/project/ping/config/SecurityConfig.java
+++ b/src/main/java/project/ping/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package project.ping.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    // 비밀번호 암호화
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeRequests((authorize) -> authorize.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/src/main/java/project/ping/controller/MemberController.java
+++ b/src/main/java/project/ping/controller/MemberController.java
@@ -1,0 +1,39 @@
+package project.ping.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import project.ping.apiPayload.ApiResponse;
+import project.ping.dto.MemberRequestDTO;
+import project.ping.dto.MemberResponseDTO;
+import project.ping.service.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/join")
+    @Operation(summary = "일반 회원가입 API")
+    public ApiResponse<?> join(@RequestBody MemberRequestDTO.MemberJoinDTO request){
+        MemberResponseDTO.MemberJoinResultDTO result = memberService.joinMember(request);
+        return ApiResponse.onSuccess(result);
+    }
+
+    // 이메일 인증 로직
+    @PostMapping("/email")
+    @Operation(summary = "이메일 인증번호 전송 API")
+    public ApiResponse<?> sendEmail(@RequestParam String email){
+        memberService.sendMail(email);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @GetMapping("/email/verify")
+    @Operation(summary = "이메일 인증 확인 API")
+    public ApiResponse<?> verifyEmail(@RequestParam String email, @RequestParam String code){
+        memberService.verifyMail(email, code);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/project/ping/converter/MemberConverter.java
+++ b/src/main/java/project/ping/converter/MemberConverter.java
@@ -1,0 +1,30 @@
+package project.ping.converter;
+
+import project.ping.domain.Member;
+import project.ping.domain.enums.MemberStatus;
+import project.ping.dto.MemberRequestDTO;
+import project.ping.dto.MemberResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class MemberConverter {
+
+    public static Member toMember(MemberRequestDTO.MemberJoinDTO request, String name){
+        return Member.builder()
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .memberStatus(MemberStatus.ACTIVE)
+                .nickname(name)
+                .build();
+    }
+
+    public static MemberResponseDTO.MemberJoinResultDTO toJoinResult(Member member){
+        return new MemberResponseDTO.MemberJoinResultDTO().builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+
+}

--- a/src/main/java/project/ping/domain/Follow.java
+++ b/src/main/java/project/ping/domain/Follow.java
@@ -1,12 +1,15 @@
 package project.ping.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 import project.ping.domain.common.BaseEntity;
 
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Follow extends BaseEntity {
 
     @Id

--- a/src/main/java/project/ping/domain/Member.java
+++ b/src/main/java/project/ping/domain/Member.java
@@ -1,7 +1,9 @@
 package project.ping.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import project.ping.domain.common.BaseEntity;
 import project.ping.domain.enums.MemberStatus;
 
@@ -10,6 +12,9 @@ import java.util.List;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
     @Id
@@ -22,6 +27,7 @@ public class Member extends BaseEntity {
 
     private String nickname;
 
+    @Enumerated(EnumType.STRING)
     private MemberStatus memberStatus;
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
@@ -34,5 +40,10 @@ public class Member extends BaseEntity {
     // 누가 나를 팔로우하는 중인지
     @OneToMany(mappedBy = "following", fetch = FetchType.LAZY)
     private List<Follow> followerList = new ArrayList<>();
+
+    // 비밀번호 암호화
+    public void encodePassword(String password) {
+        this.password = password;
+    }
 
 }

--- a/src/main/java/project/ping/domain/Post.java
+++ b/src/main/java/project/ping/domain/Post.java
@@ -1,7 +1,7 @@
 package project.ping.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 import project.ping.domain.common.BaseEntity;
 
 import java.util.ArrayList;
@@ -9,6 +9,9 @@ import java.util.List;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
 
     @Id

--- a/src/main/java/project/ping/domain/PostImage.java
+++ b/src/main/java/project/ping/domain/PostImage.java
@@ -1,11 +1,14 @@
 package project.ping.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 import project.ping.domain.common.BaseEntity;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostImage extends BaseEntity {
 
     @Id

--- a/src/main/java/project/ping/dto/MemberRequestDTO.java
+++ b/src/main/java/project/ping/dto/MemberRequestDTO.java
@@ -1,0 +1,20 @@
+package project.ping.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+public class MemberRequestDTO {
+
+    @Getter
+    public static class MemberJoinDTO{
+
+        @NotBlank(message = "이메일은 필수 입력 값입니다")
+        @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$",
+                    message = "이메일 형식이 올바르지 않습니다.")
+        String email;
+
+        @NotBlank(message = "비밀번호는 필수 입력 값입니다")
+        String password;
+    }
+}

--- a/src/main/java/project/ping/dto/MemberResponseDTO.java
+++ b/src/main/java/project/ping/dto/MemberResponseDTO.java
@@ -1,0 +1,21 @@
+package project.ping.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class MemberResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberJoinResultDTO{
+        private Long id;
+        private String nickname;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/project/ping/repository/MemberRepository.java
+++ b/src/main/java/project/ping/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package project.ping.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import project.ping.domain.Member;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByEmail(String email);
+
+}

--- a/src/main/java/project/ping/service/MemberService.java
+++ b/src/main/java/project/ping/service/MemberService.java
@@ -1,0 +1,154 @@
+package project.ping.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import project.ping.apiPayload.exception.GeneralException;
+import project.ping.apiPayload.status.ErrorStatus;
+import project.ping.converter.MemberConverter;
+import project.ping.domain.Member;
+import project.ping.dto.MemberRequestDTO;
+import project.ping.dto.MemberResponseDTO;
+import project.ping.repository.MemberRepository;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final JavaMailSender javaMailSender;
+    private final MemberRepository memberRepository;
+    private final RedisTemplate<String, Object> redistemplate;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    String[] adjectives = {
+            "귀여운", "상큼한", "시끄러운", "엉뚱한", "달콤한",
+            "반짝이는", "깜찍한", "멋진", "순한", "포근한",
+            "강력한", "차가운", "따뜻한", "느긋한", "조용한",
+            "야무진", "씩씩한", "유쾌한", "반항적인", "엉망진창인",
+            "정직한", "똑똑한", "용감한", "사랑스러운", "화려한",
+            "재치있는", "쿨한", "따끔한", "긍정적인", "재빠른",
+            "기운찬", "해맑은", "까칠한", "반가운", "비밀스러운",
+            "심심한", "알쏭달쏭한", "고요한", "폭신폭신한", "새침한",
+            "신비로운", "재밌는", "독특한", "엉성한", "정많은",
+            "느끼한", "느린", "진지한", "우울한", "도도한",
+            "흥분한", "헷갈리는", "짜증나는", "고약한", "까다로운",
+            "사나운", "삐딱한", "게으른", "수줍은", "무뚝뚝한",
+            "시무룩한", "차분한", "능글맞은", "오만한", "건방진",
+            "깐깐한", "용의주도한", "허세부리는", "버릇없는", "엉뚱한",
+            "철없는", "소심한", "기발한", "변덕스러운", "어이없는",
+            "불타는", "지루한", "야릇한", "뒤죽박죽인", "말없는",
+            "겁많은", "장난꾸러기", "감성적인", "독설가인", "논리적인",
+            "귀찮은", "거만한", "냉소적인", "친절한", "친근한",
+            "다정한", "활기찬", "열정적인", "생기있는", "엉뚱발랄한",
+            "엉클어진", "몽환적인", "날카로운", "묘한", "느긋느긋한"
+    };
+
+    String[] animalNouns = {
+            "강아지", "고양이", "호랑이", "사자", "토끼",
+            "여우", "늑대", "곰", "다람쥐", "햄스터",
+            "고슴도치", "판다", "너구리", "치타", "표범",
+            "기린", "코끼리", "하마", "악어", "돼지",
+            "소", "염소", "양", "오리", "백조",
+            "거위", "닭", "병아리", "수달", "비버",
+            "캥거루", "왈라비", "코알라", "낙타", "말",
+            "얼룩말", "하이에나", "도마뱀", "카멜레온", "타조",
+            "독수리", "부엉이", "참새", "비둘기", "까마귀",
+            "앵무새", "갈매기", "제비", "박쥐", "펭귄",
+            "돌고래", "고래", "상어", "문어", "오징어",
+            "가재", "게", "불가사리", "해파리", "고등어",
+            "참치", "연어", "메기", "붕어", "잉어",
+            "금붕어", "개구리", "두꺼비", "도롱뇽", "달팽이",
+            "지렁이", "벌", "나비", "잠자리", "개미",
+            "모기", "파리", "메뚜기", "귀뚜라미", "베짱이",
+            "거미", "진드기", "무당벌레", "사슴벌레", "장수풍뎅이",
+            "하늘소", "공작", "고라니", "노루", "사슴",
+            "멧돼지", "두루미", "두더지", "뱀", "이구아나",
+            "킹크랩", "쥐", "너구리", "담비", "스컹크", "러브버그"
+    };
+
+    // 일반 회원가입
+    public MemberResponseDTO.MemberJoinResultDTO joinMember(MemberRequestDTO.MemberJoinDTO request){
+        // 이메일 중복 여부 확인
+        if(memberRepository.existsByEmail(request.getEmail())){
+            throw new GeneralException(ErrorStatus.EXIST_EMAIL);
+        }
+
+        // DTO -> 엔티티로 변경
+        String name = makeRandomName();
+        Member member = MemberConverter.toMember(request, name);
+
+        // 비밀번호 암호화
+        member.encodePassword(bCryptPasswordEncoder.encode(member.getPassword()));
+        memberRepository.save(member);
+        return MemberConverter.toJoinResult(member);
+    }
+
+    // 랜덤 닉네임 생성
+    public String makeRandomName(){
+        Random random = new Random();
+        int adjIndex = random.nextInt(adjectives.length);
+        int nounIndex = random.nextInt(animalNouns.length);
+
+        String adj = adjectives[adjIndex];
+        String noun = animalNouns[nounIndex];
+
+        return adj + " " + noun;
+    }
+
+    // 이메일 인증번호 전송
+    public void sendMail(String email){
+        // 6자리 인증번호 생성
+        int number = (int)(Math.random() * 90000)+100000;
+        // 메시지 생성
+        try{
+            MimeMessage message = javaMailSender.createMimeMessage();
+
+            MimeMessageHelper helper = new MimeMessageHelper(message, true,  "UTF-8");
+            helper.setSubject("[Ping] 이메일 인증 번호");
+            helper.setTo(email);
+            helper.setFrom(new InternetAddress("ping@ping.com", "ping", "UTF-8"));
+            String body = "";
+            body += "<h3>" + "요청하신 인증번호입니다."+"</h3>";
+            body += "<h1>" + number + "</h1>";
+            body += "<h3>" + "화면으로 돌아가 인증번호를 입력해주세요" + "</h3>";
+            body += "<h3>" + "감사합니다" + "</h3>";
+            helper.setText(body, true);
+
+            javaMailSender.send(message);
+        } catch(MessagingException | UnsupportedEncodingException e){
+            log.error("Error Sending email", e);
+        }
+
+        // redis에 인증번호 3분간 저장
+        ValueOperations<String, Object> ops = redistemplate.opsForValue();
+        ops.set("EmailCode"+email, number+"", 180, TimeUnit.SECONDS);
+    }
+
+    // 이메일 인증번호 확인
+    public void verifyMail(String email, String code){
+        ValueOperations<String, Object> ops = redistemplate.opsForValue();
+        String emailCode = (String) ops.get("EmailCode"+email);
+        if(emailCode == null){
+            throw new GeneralException(ErrorStatus.EXPIRE_EMAIL_CODE);
+        }
+        if(!code.equals(emailCode)){
+            throw new GeneralException(ErrorStatus.WRONG_EMAIL_VERIFICATOIN);
+        }
+    }
+
+}


### PR DESCRIPTION
## 💡 관련 이슈
- #3 


## 📢 작업 내용
- 이메일, 비밀번호를 통해 회원가입을 진행
- 회원가입 시, 해당 이메일로 인증하도록 구현 (redis 사용)
- 회원가입을 하면 랜덤 닉네임이 제공되도록 구현


## 🗨️ 리뷰 요구 사항(선택)
- x


## ✅ 체크 리스트
 - [x] 코드가 정상적으로 컴파일되나요?
 - [x] 이슈 내용을 전부 구현했나요?
 - [x] 작업 기간 내에 개발을 완료했나요?
 - [ ] 리뷰어를 선택했나요?
 - [x] 라벨을 지정했나요?
