### PR TITLE
[FEAT] 일반 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
+	// jjwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
 
 }

--- a/src/main/java/project/ping/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/project/ping/apiPayload/status/ErrorStatus.java
@@ -24,6 +24,10 @@ public enum ErrorStatus {
     EXPIRE_EMAIL_CODE(HttpStatus.BAD_REQUEST, "MEMBER4003", "이메일 인증번호가 만료되었습니다. 다시 인증번호를 받으세요"),
     NOT_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4004", "존재하지 않는 이메일입니다. 다시 입력해주세요"),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER4005", "일치하지 않는 비밀번호입니다. 다시 입력해주세요"),
+    WRONG_TYPE_SIGNATURE(HttpStatus.BAD_REQUEST, "MEMBER4006", "잘못된 JWT 서명입니다."),
+    TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "MEMBER4007", "만료된 JWT 토큰입니다."),
+    WRONG_TYPE_TOKEN(HttpStatus.BAD_REQUEST, "MEMBER4008", "지원되지 않는 JWT 토큰입니다."),
+    NOT_VALID_TOKEN(HttpStatus.BAD_REQUEST, "MEMBER4009", "JWT 토큰이 잘못되었습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/project/ping/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/project/ping/apiPayload/status/ErrorStatus.java
@@ -22,6 +22,8 @@ public enum ErrorStatus {
     EXIST_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4001", "이미 회원가입한 이메일입니다. 다른 이메일로 가입하세요"),
     WRONG_EMAIL_VERIFICATOIN(HttpStatus.BAD_REQUEST, "MEMBER4002", "이메일 인증번호가 틀렸습니다. 다시 입력해주세요"),
     EXPIRE_EMAIL_CODE(HttpStatus.BAD_REQUEST, "MEMBER4003", "이메일 인증번호가 만료되었습니다. 다시 인증번호를 받으세요"),
+    NOT_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4004", "존재하지 않는 이메일입니다. 다시 입력해주세요"),
+    WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER4005", "일치하지 않는 비밀번호입니다. 다시 입력해주세요"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/project/ping/controller/MemberController.java
+++ b/src/main/java/project/ping/controller/MemberController.java
@@ -2,8 +2,12 @@ package project.ping.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import project.ping.apiPayload.ApiResponse;
+import project.ping.dto.JwtDTO;
 import project.ping.dto.MemberRequestDTO;
 import project.ping.dto.MemberResponseDTO;
 import project.ping.service.MemberService;
@@ -18,11 +22,9 @@ public class MemberController {
     @PostMapping("/join")
     @Operation(summary = "일반 회원가입 API")
     public ApiResponse<?> join(@RequestBody MemberRequestDTO.MemberJoinDTO request){
-        MemberResponseDTO.MemberJoinResultDTO result = memberService.joinMember(request);
-        return ApiResponse.onSuccess(result);
+        return ApiResponse.onSuccess(memberService.joinMember(request));
     }
 
-    // 이메일 인증 로직
     @PostMapping("/email")
     @Operation(summary = "이메일 인증번호 전송 API")
     public ApiResponse<?> sendEmail(@RequestParam String email){
@@ -36,4 +38,12 @@ public class MemberController {
         memberService.verifyMail(email, code);
         return ApiResponse.onSuccess(null);
     }
+
+    @PostMapping("/login")
+    @Operation(summary = "일반 로그인 API")
+    public ResponseEntity<ApiResponse<?>> login(@RequestBody MemberRequestDTO.MemberJoinDTO request){
+        HttpHeaders result = memberService.loginMember(request);
+        return ResponseEntity.ok().headers(result).body(ApiResponse.onSuccess(null));
+    }
+
 }

--- a/src/main/java/project/ping/dto/JwtDTO.java
+++ b/src/main/java/project/ping/dto/JwtDTO.java
@@ -1,0 +1,17 @@
+package project.ping.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class JwtDTO {
+
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/src/main/java/project/ping/repository/MemberRepository.java
+++ b/src/main/java/project/ping/repository/MemberRepository.java
@@ -4,9 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import project.ping.domain.Member;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
 
 }

--- a/src/main/java/project/ping/security/auth/MemberDetail.java
+++ b/src/main/java/project/ping/security/auth/MemberDetail.java
@@ -1,0 +1,56 @@
+package project.ping.security.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import project.ping.domain.Member;
+
+import java.util.Collection;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Getter
+public class MemberDetail implements UserDetails {
+
+    private final Member member;
+
+    public static MemberDetail createMemberDetail(Member member) {
+        return new MemberDetail(member);
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getNickname();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/project/ping/security/auth/MemberDetailService.java
+++ b/src/main/java/project/ping/security/auth/MemberDetailService.java
@@ -1,0 +1,29 @@
+package project.ping.security.auth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import project.ping.domain.Member;
+import project.ping.repository.MemberRepository;
+
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberDetailService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    // 사용자 이메일을 통해 사용자의 정보를 가져오는 메서드
+    @Override
+    public MemberDetail loadUserByUsername(String email) throws UsernameNotFoundException {
+        Optional<Member> member = memberRepository.findByEmail(email);
+        if(member.isEmpty()) throw new UsernameNotFoundException(email);
+        return MemberDetail.createMemberDetail(member.get());
+    }
+
+}

--- a/src/main/java/project/ping/security/filter/JwtAccessDeniedHandler.java
+++ b/src/main/java/project/ping/security/filter/JwtAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package project.ping.security.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import project.ping.apiPayload.ApiResponse;
+import project.ping.apiPayload.status.ErrorStatus;
+
+import java.io.IOException;
+
+// 인가되지 않은 요청(권한 부족)에 대한 처리를 담당
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws ServletException, IOException {
+        log.error("No Authorities", accessDeniedException);
+        ApiResponse<Object> apiResponse =
+                ApiResponse.onFailure(ErrorStatus._FORBIDDEN, null);
+
+        String responseBody = new ObjectMapper().writeValueAsString(apiResponse);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/project/ping/security/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/project/ping/security/filter/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package project.ping.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import project.ping.apiPayload.ApiResponse;
+import project.ping.apiPayload.status.ErrorStatus;
+
+import java.io.IOException;
+
+// 인증되지 않은 요청에 대한 처리를 담당
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        log.error("Not Authenticated Request", authException);
+        ApiResponse<Object> apiResponse =
+                ApiResponse.onFailure(ErrorStatus._UNAUTHORIZED, null);
+        String responseBody = new ObjectMapper().writeValueAsString(apiResponse);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/project/ping/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/project/ping/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,35 @@
+package project.ping.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import project.ping.security.jwt.JwtTokenProvider;
+
+import java.io.IOException;
+
+// JWT 토큰을 사용하여 사용자의 인증을 처리하는 역할
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 요청 헤더에서 토큰 추출하기
+        String token = jwtTokenProvider.resolveToken(request);
+        // 토큰 유효성 검사
+        if(token != null && jwtTokenProvider.validateToken(token)){
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        // 다음 필터로 이동
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/project/ping/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/project/ping/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,43 @@
+package project.ping.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import project.ping.apiPayload.ApiResponse;
+import project.ping.apiPayload.exception.GeneralException;
+import project.ping.apiPayload.status.ErrorStatus;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        }
+        catch (GeneralException ge) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, request, response, ge.getErrorStatus());
+        }
+    }
+
+    public void setErrorResponse(HttpStatus status, HttpServletRequest req,
+                                 HttpServletResponse res, ErrorStatus e) throws IOException {
+        res.setStatus(status.value());
+        res.setContentType("application/json");
+        res.setCharacterEncoding("UTF-8");
+
+        ApiResponse<?> apiResponse = ApiResponse.onFailure(e, null);
+        res.getWriter().write(new ObjectMapper().writeValueAsString(apiResponse));
+    }
+
+}

--- a/src/main/java/project/ping/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/project/ping/security/jwt/JwtTokenProvider.java
@@ -1,12 +1,20 @@
 package project.ping.security.jwt;
 
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
+import project.ping.apiPayload.exception.GeneralException;
+import project.ping.apiPayload.status.ErrorStatus;
 import project.ping.dto.JwtDTO;
+import project.ping.security.auth.MemberDetail;
+import project.ping.security.auth.MemberDetailService;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
@@ -14,7 +22,10 @@ import java.util.Date;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class JwtTokenProvider implements InitializingBean {
+
+    private final MemberDetailService memberDetailService;
 
     @Value("${spring.jwt.secret}")
     private String secret;
@@ -60,6 +71,54 @@ public class JwtTokenProvider implements InitializingBean {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
+    }
+
+    // 요청 헤더에서 토큰 뽑아내기
+    public String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if(header == null || !header.startsWith("Bearer ")){
+            return null;
+        }
+        return header.substring(7).trim();
+    }
+
+    // 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try{
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        }catch (SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+            throw new GeneralException(ErrorStatus.WRONG_TYPE_SIGNATURE);
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+            throw new GeneralException(ErrorStatus.TOKEN_EXPIRED);
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+            throw new GeneralException(ErrorStatus.WRONG_TYPE_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+            throw new GeneralException(ErrorStatus.NOT_VALID_TOKEN);
+        }
+    }
+
+    // 토큰을 복호화하여 claim 정보를 통해 인증 객체(Authentication) 생성
+    public Authentication getAuthentication(String token) {
+        MemberDetail memberDetail = memberDetailService.loadUserByUsername(this.getEmail(token));
+        return new UsernamePasswordAuthenticationToken(memberDetail, null, memberDetail.getAuthorities());
+    }
+
+    // 토큰에서 이메일 추출
+    public String getEmail(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("email", String.class);
     }
 
 }

--- a/src/main/java/project/ping/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/project/ping/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,65 @@
+package project.ping.security.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import project.ping.dto.JwtDTO;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+public class JwtTokenProvider implements InitializingBean {
+
+    @Value("${spring.jwt.secret}")
+    private String secret;
+
+    private SecretKey secretKey;
+
+    @Value("${spring.jwt.token.access_expiration}")
+    private Long accessTokenExpiration;
+
+    @Value("${spring.jwt.token.refresh_expiration}")
+    private Long refreshTokenExpiration;
+
+    // SecretKey 생성하기
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // 로그인 시, 액세스 토큰과 리프레시 토큰을 발급
+    public JwtDTO createToken(Long memberId, String email){
+        Date now = new Date();
+
+        String accessToken = Jwts.builder()
+                .claim("memberId", memberId)
+                .claim("email", email)
+                .claim("token-type", "access-token")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + accessTokenExpiration))
+                .signWith(secretKey)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .claim("memberId", memberId)
+                .claim("email", email)
+                .claim("token-type", "refresh-token")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + refreshTokenExpiration))
+                .signWith(secretKey)
+                .compact();
+
+
+;       return JwtDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+}

--- a/src/main/java/project/ping/service/MemberService.java
+++ b/src/main/java/project/ping/service/MemberService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpHeaders;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -16,9 +17,11 @@ import project.ping.apiPayload.exception.GeneralException;
 import project.ping.apiPayload.status.ErrorStatus;
 import project.ping.converter.MemberConverter;
 import project.ping.domain.Member;
+import project.ping.dto.JwtDTO;
 import project.ping.dto.MemberRequestDTO;
 import project.ping.dto.MemberResponseDTO;
 import project.ping.repository.MemberRepository;
+import project.ping.security.jwt.JwtTokenProvider;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Random;
@@ -32,6 +35,7 @@ public class MemberService {
 
     private final JavaMailSender javaMailSender;
     private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, Object> redistemplate;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
@@ -149,6 +153,29 @@ public class MemberService {
         if(!code.equals(emailCode)){
             throw new GeneralException(ErrorStatus.WRONG_EMAIL_VERIFICATOIN);
         }
+    }
+
+    // 일반 로그인
+    public HttpHeaders loginMember(MemberRequestDTO.MemberJoinDTO request) {
+        // 해당 이메일 존재 여부 및 비밀번호 확인
+        Member member = memberRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_EMAIL));
+
+        if(!bCryptPasswordEncoder.matches(request.getPassword(), member.getPassword())){
+            throw new GeneralException(ErrorStatus.WRONG_PASSWORD);
+        }
+
+        // 액세스 토큰 및 리프레시 토큰을 응답으로 전송
+        JwtDTO jwtDTO = jwtTokenProvider.createToken(member.getId(), member.getEmail());
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization","Bearer" + jwtDTO.getAccessToken());
+        headers.add("Refresh-Token", jwtDTO.getRefreshToken());
+
+        // 리프레시 토큰은 redis에 저장해야함
+        ValueOperations<String, Object> ops = redistemplate.opsForValue();
+        ops.set("refresh-token " + member.getEmail(), jwtDTO.getRefreshToken(), 7, TimeUnit.DAYS);
+
+        return headers;
     }
 
 }

--- a/src/main/java/project/ping/service/MemberService.java
+++ b/src/main/java/project/ping/service/MemberService.java
@@ -168,7 +168,7 @@ public class MemberService {
         // 액세스 토큰 및 리프레시 토큰을 응답으로 전송
         JwtDTO jwtDTO = jwtTokenProvider.createToken(member.getId(), member.getEmail());
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization","Bearer" + jwtDTO.getAccessToken());
+        headers.add("Authorization","Bearer " + jwtDTO.getAccessToken());
         headers.add("Refresh-Token", jwtDTO.getRefreshToken());
 
         // 리프레시 토큰은 redis에 저장해야함


### PR DESCRIPTION
## 💡 관련 이슈
- #5 


## 📢 작업 내용
- 이메일, 비밀번호를 통해서 로그인하는 비즈니스 로직 작성
- SecurityConfig 작성 및 관련 의존성 추가(jjwt)
- 스프링 시큐리티 필터와 핸들러 작성 및 추가
   (JwtAuthenticationFilter, JwtExceptionFilter, JwtAuthenticationEntryPoint, JwtAccessDeniedHandler)
- JwtTokenProvider, MemberDetailService, MemberDetail 작성


## 🗨️ 리뷰 요구 사항(선택)
- x


## ✅ 체크 리스트
 - [x] 코드가 정상적으로 컴파일되나요?
 - [x] 이슈 내용을 전부 구현했나요?
 - [x] 작업 기간 내에 개발을 완료했나요?
 - [ ] 리뷰어를 선택했나요?
 - [x] 라벨을 지정했나요?
