### PR TITLE
[FEAT] 마이페이지 조회 API 구현

### DIFF
--- a/src/main/java/project/ping/controller/MemberController.java
+++ b/src/main/java/project/ping/controller/MemberController.java
@@ -6,11 +6,13 @@ import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import project.ping.apiPayload.ApiResponse;
 import project.ping.dto.JwtDTO;
 import project.ping.dto.MemberRequestDTO;
 import project.ping.dto.MemberResponseDTO;
+import project.ping.security.auth.MemberDetail;
 import project.ping.service.MemberService;
 
 @RestController
@@ -46,6 +48,12 @@ public class MemberController {
     public ResponseEntity<ApiResponse<?>> login(@RequestBody MemberRequestDTO.MemberJoinDTO request){
         HttpHeaders result = memberService.loginMember(request);
         return ResponseEntity.ok().headers(result).body(ApiResponse.onSuccess(null));
+    }
+
+    @GetMapping("/myPage")
+    @Operation(summary = "마이페이지 조회 API")
+    public ApiResponse<?> myPage(@AuthenticationPrincipal MemberDetail memberDetail){
+        return ApiResponse.onSuccess(memberService.getMyPage(memberDetail));
     }
 
 }

--- a/src/main/java/project/ping/converter/MemberConverter.java
+++ b/src/main/java/project/ping/converter/MemberConverter.java
@@ -26,5 +26,15 @@ public class MemberConverter {
                 .build();
     }
 
+    public static MemberResponseDTO.MyPageDTO toMyPage(Member member, Long followings, Long followers, Long post) {
+        return MemberResponseDTO.MyPageDTO.builder()
+                .nickname(member.getNickname())
+                .followings(followings)
+                .followers(followers)
+                .posts(post)
+                .build();
+    }
+
+
 
 }

--- a/src/main/java/project/ping/dto/MemberResponseDTO.java
+++ b/src/main/java/project/ping/dto/MemberResponseDTO.java
@@ -18,4 +18,15 @@ public class MemberResponseDTO {
         private String nickname;
         private LocalDateTime createdAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyPageDTO{
+        private String nickname;
+        private Long followers;
+        private Long followings;
+        private Long posts;
+    }
 }

--- a/src/main/java/project/ping/repository/FollowRepository.java
+++ b/src/main/java/project/ping/repository/FollowRepository.java
@@ -1,6 +1,8 @@
 package project.ping.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import project.ping.domain.Follow;
 import project.ping.domain.Member;
 
@@ -15,4 +17,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     List<Follow> findByFollower(Member follower);
 
     List<Follow> findByFollowing(Member following);
+
+    Long countByFollower(@Param("member") Member member);
+
+    Long countByFollowing(@Param("member") Member member);
 }

--- a/src/main/java/project/ping/repository/FollowRepository.java
+++ b/src/main/java/project/ping/repository/FollowRepository.java
@@ -18,7 +18,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     List<Follow> findByFollowing(Member following);
 
-    Long countByFollower(@Param("member") Member member);
+    Long countByFollower(Member member);
 
-    Long countByFollowing(@Param("member") Member member);
+    Long countByFollowing(Member member);
 }

--- a/src/main/java/project/ping/repository/PostRepository.java
+++ b/src/main/java/project/ping/repository/PostRepository.java
@@ -25,4 +25,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByMember(Member member);
 
+    Long countByMember(Member member);
 }

--- a/src/main/java/project/ping/service/MemberService.java
+++ b/src/main/java/project/ping/service/MemberService.java
@@ -20,7 +20,10 @@ import project.ping.domain.Member;
 import project.ping.dto.JwtDTO;
 import project.ping.dto.MemberRequestDTO;
 import project.ping.dto.MemberResponseDTO;
+import project.ping.repository.FollowRepository;
 import project.ping.repository.MemberRepository;
+import project.ping.repository.PostRepository;
+import project.ping.security.auth.MemberDetail;
 import project.ping.security.jwt.JwtTokenProvider;
 
 import java.io.UnsupportedEncodingException;
@@ -38,6 +41,8 @@ public class MemberService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, Object> redistemplate;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final FollowRepository followRepository;
+    private final PostRepository postRepository;
 
     String[] adjectives = {
             "귀여운", "상큼한", "시끄러운", "엉뚱한", "달콤한",
@@ -178,4 +183,11 @@ public class MemberService {
         return headers;
     }
 
+    public MemberResponseDTO.MyPageDTO getMyPage(MemberDetail memberDetail) {
+        Member member = memberDetail.getMember();
+        Long followers = followRepository.countByFollowing(member);
+        Long followings = followRepository.countByFollower(member);
+        Long post = postRepository.countByMember(member);
+        return MemberConverter.toMyPage(member, followings, followers, post);
+    }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #33 


## 📢 작업 내용
- 마이페이지 정보(닉네임, 팔로워수, 팔로잉수, 게시글 수)를 조회하는 로직 구현


## 🗨️ 리뷰 요구 사항(선택)
- x


## ✅ 체크 리스트
 - [x] 코드가 정상적으로 컴파일되나요?
 - [x] 이슈 내용을 전부 구현했나요?
 - [x] 작업 기간 내에 개발을 완료했나요?
 - [ ] 리뷰어를 선택했나요?
 - [x] 라벨을 지정했나요?
